### PR TITLE
docs(readme): replaced default composer readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,40 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Lightspeed Log
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+A Laravel-based mini app to demonstrate automated API testing with Cypress.
+Includes a POST endpoint and a test that programmatically clicks a button to verify API response behavior.
 
-## About Laravel
+---
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Quick Start
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+### 1. Clone and Install Laravel
+```bash
+git clone https://github.com/0x20n1n/lightspeed-log.git
+cd lightspeed-log
+composer install
+php artisan serve
+```
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+App runs at: http://127.0.0.1:8000
 
-## Learning Laravel
+### 2. Run Cypress E2E Test
+```
+npm install
+npx cypress open
+```
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+Then in the Cypress UI, select lightspeed-button.cy.js to run the test.
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+What It Does
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+- Serves a Laravel app with a POST endpoint (/api/v1/test-call)
+- HTML button triggers the API call
+- Cypress test clicks the button and logs success or error response
 
-## Laravel Sponsors
+## Issues faced
+During development, I encountered Laravel 12’s shift in route registration behavior.
+- **Laravel 12 route registration:** Unlike previous versions, Laravel 12 does not automatically load `api.php` routes. I had to configure route loading explicitly via `bootstrap/app.php` and apply the appropriate `api` middleware group manually in `routes/web.php`. Verifying with `php artisan route:list` helped to confirm when Laravel actually picked up the registered path configurations.
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+- **419 Page Expired (CSRF) errors:** Initially caused by incorrect or missing CSRF exceptions. The first attempt used a blank `VerifyCsrfToken` class scaffolded via `php artisan make:middleware`, which lacked Laravel’s internal CSRF logic. Replacing it with the correct extended class and adding `'/api/v1/test-call'` to the `$except` array resolved it.
 
-### Premium Partners
-
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development/)**
-- **[Active Logic](https://activelogic.com)**
-
-## Contributing
-
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
-
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+- **Bootstrap configuration quirks:** Laravel 12 centralizes middleware and routing configuration in `bootstrap/app.php`. Understanding and using the `withRouting()` and `withMiddleware()` methods was crucial to wire everything up properly.


### PR DESCRIPTION
### Summary

- Replaced the default Laravel README with a custom project overview
- Added setup instructions for Laravel and Cypress
- Included a short "Issues faced" section to document key hurdles

### Checklist
- [x] Docs updated
- [ ] New code added
- [ ] Tests written or updated

### Notes
This is a documentation-only update — no functional code changes were made.
